### PR TITLE
Отсутствует $aVars['oUserProfile']

### DIFF
--- a/classes/hooks/HookUserban.class.php
+++ b/classes/hooks/HookUserban.class.php
@@ -109,9 +109,11 @@ class PluginAdmin_HookUserban extends Hook {
 		/*
 		 * видно либо хозяину профиля либо админам (этот метод добавлен в профиль админки и на сайте)
 		 */
-		if ($this->User_GetUserCurrent() and $oBan = $aVars['oUserProfile']->getBanned()) {
-			$this->Viewer_Assign('oBan', $oBan);
-			return $this->Viewer_Fetch(Plugin::GetTemplatePath(__CLASS__) . 'actions/ActionAdmin/users/profile_user_banned_msg.tpl');
+		if(isset($aVars['oUserProfile'])) {
+			if ($this->User_GetUserCurrent() and $oBan = $aVars['oUserProfile']->getBanned()) {
+				$this->Viewer_Assign('oBan', $oBan);
+				return $this->Viewer_Fetch(Plugin::GetTemplatePath(__CLASS__) . 'actions/ActionAdmin/users/profile_user_banned_msg.tpl');
+			}
 		}
 	}
 


### PR DESCRIPTION
Крашится профиль из-за отсутствия $aVars['oUserProfile'].
[2014-08-17 00:20:16] default.ALERT 6908 64827a1: Fatal Error (E_ERROR): Call to a member function getBanned() on a non-object {"file":"Z:\home\livestreet\www\application\plugins\admin\classes\hooks\HookUserban.class.php","line":112}
